### PR TITLE
Cubesat concepts 

### DIFF
--- a/_posts/cubesat sizes.md
+++ b/_posts/cubesat sizes.md
@@ -1,0 +1,23 @@
+
+---
+layout: post
+title:  “cubesat sizes"
+image: 'https://www.nasa.gov/sites/default/files/thumbnails/image/what_are_cubesats.png'
+date:   2017-08-29 00:04:01
+tags:
+- mongodb
+description: 'CubeSats are a class of nanosatellites that utilization a standard size and shape factor. The standard CubeSat estimate utilizes a "one unit" or "1U" measuring 10x10x10 cms and is extendable to bigger sizes; 1.5, 2, 3, 6, and even 12U.
+ '
+categories: Satellite 
+- Learn GH 
+---
+
+CubeSats are a class of nanosatellites that utilization a standard size and shape factor. The standard CubeSat estimate utilizes a "one unit" or "1U" measuring 10x10x10 cms and is extendable to bigger sizes; 1.5, 2, 3, 6, and even 12U. Initially created in 1999 by California Polytechnic State University at San Luis Obispo (Cal Poly) and Stanford University to give a stage to training and space investigation. The improvement of CubeSats has progressed into it's own particular industry with government, industry and the scholarly world working together for regularly expanding capacities. CubeSats now give a financially savvy stage to science examinations, new innovation exhibits and propelled mission ideas utilizing groups of stars, swarms disaggregated framework.
+Satellite sizes: 
+![sizes](https://www.nasa.gov/sites/default/files/thumbnails/image/what_are_cubesats.png
+ “Sizes")
+
+Inline-style: 
+![anatomy of cubesat mission
+ ](http://www.cubesat.org/news-feed/2016/4/7/ula-releases-application-for-university-cubesat-competition
+ “anatomy of cubesat mission")


### PR DESCRIPTION
---
layout: post
title:  “cubesat concepts"
image: ''
date:   2017-08-29 00:04:01
tags:
- mongodb
description: 'The CubeSat idea and program began in 1999 at SSDL (Space Systems Development Laboratory) of Stanford University under the administration of Robert J. Twiggs. [Note: The CubeSat idea was at first displayed and proposed by R. J. Twiggs at the USSS (University Space Systems Symposium), Kauai Beach Hotel, Kauai, Hawaii, Nov. 6-8, 1999].
 '
categories: Satellite 
- Learn GH 
---

The CubeSat idea and program began in 1999 at SSDL (Space Systems Development Laboratory) of Stanford University under the administration of Robert J. Twiggs. [Note: The CubeSat idea was at first displayed and proposed by R. J. Twiggs at the USSS (University Space Systems Symposium), Kauai Beach Hotel, Kauai, Hawaii, Nov. 6-8, 1999]. 

The thought was to meet an instructive need to characterize an important satellite mission that could be created inside a time period of a year or two, be of minimal effort, and be of low mass for decreased dispatch costs. - It would appear picosatellites offer exceptionally encouraging situations to show new little scale space innovations and mission ideas (testbed capacity for low-power and low-mass gadgets, for example, MEMS). CubeSats, joined with new sensor, interchanges, and systems administration abilities, might have the capacity to complete arrangement flight exhibitions in help of multi-point perceptions. - In the interim, Stanford University and California Polytechnic State University in San Luis Obispo, CA (alluded to as CalPoly) have joined endeavors to build up a methods for propelling little standard picosatellites called CubeSats.
Satellite sizes: 
![cubesat concepts
 ](https://directory.eoportal.org/documents/163813/513727/CubeSatDeployers_Auto23
 “cubesat concepts
 ")
